### PR TITLE
Update table.multi.r

### DIFF
--- a/R/table.multi.r
+++ b/R/table.multi.r
@@ -168,7 +168,7 @@ multi.split <- function (var, split.char="/", mnames = NULL) {
   result <- matrix(data = 0, nrow = length(var), ncol = length(lev))
   char.var <- as.character(var)
   for (i in 1:length(lev)) {
-    result[grep(lev[i], char.var, fixed = TRUE), i] <- 1
+    result[char.var %in% lev[i], i] <- 1
   }
   result <- data.frame(result)
   colnames(result) <- mnames


### PR DESCRIPTION
Fix false positive matches with grep in multi.split eg "Apple" also matches "Crab Apple".

Minimum reproducible example of previous error (should only be 1 match on "Apple":

      fruits = c("Apple/Pear", "Crab Apple/Peach")
      library(testthat)
      test_that({
          t1 <- as.data.frame(questionr::multi.split(fruits))
          expect_equal(sum(t1[["fruits.Apple"]]),1)
      })