### PR TITLE
multi.split: Handle special regex characters in var values or split.char.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     htmltools,
     graphics,
     stats,
-    utils
+    utils,
+    Hmisc
 Suggests:
     memisc,
     testthat,

--- a/R/table.multi.r
+++ b/R/table.multi.r
@@ -161,10 +161,12 @@ cross.multi.table <- function(df, crossvar, weights=NULL, digits=1, freq=FALSE, 
 multi.split <- function (var, split.char="/", mnames = NULL) {
   vname <- deparse(substitute(var))
   lev <- levels(factor(var))
-  lev <- unique(unlist(strsplit(lev, split.char)))
+  lev <- unique(unlist(strsplit(lev, split.char, fixed = TRUE)))
   if (is.null(mnames)) 
     mnames <- gsub(" ", "_", paste(vname, lev, sep = "."))
   else mnames <- paste(vname, mnames, sep = ".")
+  lev <- Hmisc::escapeRegex(lev)
+  split.char <- Hmisc::escapeRegex(split.char)
   result <- matrix(data = 0, nrow = length(var), ncol = length(lev))
   char.var <- as.character(var)
   for (i in 1:length(lev)) {


### PR DESCRIPTION
multi.split doesn't produce correct output when var values contain special characters for regex eg '(' or '$'., or if split.char special char isn't properly escaped.

So I added Hmisc::escapeRegex to split.char and lev within the function to protect from this and fixed = T to the strsplit so you never have to escape function inputs.

Example below:
v <- c("red (fruit)|blue (cheese)", "green $", "red (fruit)|green $", "blue(cheese)|red (fruit)",
       "orange|apple")
multi.split(v, split.char = "|")
testthat::expect_equal(sum(colSums(multi_split(v, split.char = "|"))),9)
