### PR TITLE
missing_values not covered anymore by labelled

### DIFF
--- a/R/describe.R
+++ b/R/describe.R
@@ -162,7 +162,6 @@
 `describe.labelled` <- 
   function(x, n = 5, show.length = TRUE, ...) {
     vl <- .get_val_labels(x)
-    mv <- .get_missing_val(x)
     if (is.numeric(x)) {
       class(x) <- "labelled numeric"
       res <- describe.numeric(x, n = n, show.length = show.length, ...)
@@ -176,9 +175,7 @@
     }
     if (!is.null(vl))
       res <- paste0(res, "\n", length(vl), " value labels: ", paste0("[", vl, "] ", names(vl), collapse = " "))
-    if (!is.null(mv))
-      res <- paste0(res, "\n", length(mv), " defined missing values: ", paste0(mv, collapse = ", "))
-    
+
     class(res) <- "description"
     return(res)
   }

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -32,14 +32,3 @@
   }
 }
 
-.get_missing_val <- function(x) {
-  if (requireNamespace("labelled", quietly = TRUE))
-    return(labelled::missing_val(x))
-    else {
-      miss <- attr(x, "labels", exact = TRUE)[attr(x, "is_na", exact = TRUE)]
-      if (length(miss) > 0)
-        return(miss)
-      else
-        return(NULL)
-    }
-}


### PR DESCRIPTION
Following last version of haven, missing values are not covered by the labelled class.

This require a fix in describe() for labelled vectors.