### PR TITLE
Specify `details = TRUE` when calling `look_for()` in `describe()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ SystemRequirements: xclip (Linux)
 VignetteBuilder: knitr
 URL: https://juba.github.io/questionr/
 BugReports: https://github.com/juba/questionr/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/describe.R
+++ b/R/describe.R
@@ -191,8 +191,6 @@
 #' @rdname describe
 #' @aliases describe.haven_labelled
 #' @examples 
-#' data(fecondite)
-#' describe(femmes$milieu)
 #' @export
 `describe.haven_labelled` <- 
   function(x, n = 10, show.length = TRUE, freq.n.max = 10, ...) {
@@ -240,8 +238,11 @@
 #' describe(hdv2003, "trav*")
 #' describe(hdv2003, "trav|lecture")
 #' describe(hdv2003, "trav", "lecture")
-#' describe(femmes)
-#' describe(femmes, "ident")
+#' 
+#' data(fertility)
+#' describe(women$residency)
+#' describe(women)
+#' describe(women, "id")
 #' @export
 
 `describe.data.frame` <- 
@@ -250,7 +251,7 @@
     x <- labelled::to_labelled(x)
     
     # select variables
-    s <- lookfor(x, ...)$variable
+    s <- lookfor(x, ..., details = FALSE)$variable
     
     if (is.null(s)) 
       return(NULL)

--- a/man/describe.Rd
+++ b/man/describe.Rd
@@ -55,15 +55,16 @@ See examples.
 data(hdv2003)
 describe(hdv2003$sexe)
 describe(hdv2003$age)
-data(fecondite)
-describe(femmes$milieu)
 describe(hdv2003)
 describe(hdv2003, "cuisine", "heures.tv")
 describe(hdv2003, "trav*")
 describe(hdv2003, "trav|lecture")
 describe(hdv2003, "trav", "lecture")
-describe(femmes)
-describe(femmes, "ident")
+
+data(fertility)
+describe(women$residency)
+describe(women)
+describe(women, "id")
 }
 \seealso{
 \code{\link{lookfor}}

--- a/man/lookfor.Rd
+++ b/man/lookfor.Rd
@@ -15,7 +15,9 @@ look_for(data, ..., labels = TRUE, ignore.case = TRUE, details = FALSE)
 \arguments{
 \item{data}{a data frame}
 
-\item{...}{list of keywords, a character string (or several character strings), which can be formatted as a regular expression suitable for a \code{grep} pattern, or a vector of keywords; displays all variables if not specified}
+\item{...}{list of keywords, a character string (or several character strings), which can be
+formatted as a regular expression suitable for a \code{\link[base:grep]{base::grep()}} pattern, or a vector of keywords;
+displays all variables if not specified}
 
 \item{labels}{whether or not to search variable labels (descriptions); \code{TRUE} by default}
 


### PR DESCRIPTION
This is a minor change, but the default value of that argument may change in a future version of labelled.