### PR TITLE
Fix printing deprecation error when passing arguments to wtd.var

### DIFF
--- a/R/weighting.R
+++ b/R/weighting.R
@@ -108,7 +108,7 @@ function (x, y = NULL, weights = NULL, digits = 3, normwt = FALSE, na.rm = TRUE,
 
 ##' @export
 
-wtd.var <- function() {
+wtd.var <- function(...) {
   stop("questionr::wtd.var has been removed. Please use Hmisc::wtd.var instead.")
 }
 


### PR DESCRIPTION
Je comprenais pas au début pourquoi j'obtenais cette erreur. :-)
```R
> wtd.var(1, 2)
Error in questionr::wtd.var(1, 2) : arguments inutilisés (1, 2)
```

Au passage, pourquoi `wtd.var` est supprimée mais pas `wtd.mean`? D'ailleurs ça ne vaudrait pas le coup d'avoir `wtd.sd` et `wtd.cor`? On peut les obtenir avec `wtd.var` et `cov.wt`, mais c'est pas idéal pour les étudiant.es.